### PR TITLE
New get_waveform_attributes() method

### DIFF
--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -14,4 +14,5 @@ This page collect useful examples on how to to some things with ``pyasdf``.
     examples/create_observed_asdf_file
     examples/process_observed
     examples/parallel_pyflex
+    examples/source_receiver_geometry
 

--- a/doc/examples/source_receiver_geometry.py
+++ b/doc/examples/source_receiver_geometry.py
@@ -1,0 +1,39 @@
+import pyasdf
+
+with pyasdf.ASDFDataSet("./asdf_example.h5", mode="r") as ds:
+    # Get dictionary of resource_id -> Lat/Lng pairs
+    events = {
+        str(e.resource_id): [(e.preferred_origin() or e.origins[0]).get(i)
+                             for i in ["latitude", "longitude"]]
+        for e in ds.events}
+
+    # Loop over all stations.
+    for s in ds.waveforms:
+        try:
+            coords = s.coordinates
+        except pyasdf.ASDFException:
+            continue
+
+        # Get set of all event ids.
+        #
+        # Get set for all event ids - the `get_waveform_attributes()`
+        # method is fairly new. If you version of pyasdf does not yet
+        # have it please update or use:
+        # group = s._WaveformAccessor__hdf5_group
+        # event_ids = list({group[i].attrs.get("event_id", None)
+        #                   for i in s.list()})
+        # event_ids = [i.decode() for i in event_ids if i]
+
+        # Note that this assumes only one event id per waveform.
+        event_ids = set(_i["event_ids"][0]
+                        for _i in s.get_waveform_attributes().values()
+                        if "event_ids" in _i)
+
+        for e_id in event_ids:
+            if e_id not in events:
+                continue
+            # Do what you want - this will be called once per src/rec pair.
+            print("%.2f %.2f %.2f %.2f" % (events[e_id][0],
+                                           events[e_id][1],
+                                           coords['latitude'],
+                                           coords['longitude']))

--- a/doc/examples/source_receiver_geometry.rst
+++ b/doc/examples/source_receiver_geometry.rst
@@ -1,0 +1,11 @@
+Calculate Source-Receiver Geometry
+==================================
+
+This simple example demonstrates a fast way to extract the source-receiver
+geometry from an ASDF file. It assumes that the ``event_id`` has been correctly
+set for each waveform and that these events are part of the global QuakeML
+file.
+
+.. literalinclude:: source_receiver_geometry.py
+    :language: python
+    :linenos:

--- a/pyasdf/tests/test_asdf_data_set.py
+++ b/pyasdf/tests/test_asdf_data_set.py
@@ -2965,3 +2965,30 @@ def test_warning_that_data_exists_shows_up_every_time(tmpdir):
         assert len(w) == 1, "Run %i" % _i
         assert w[0].category is ASDFWarning, "Run %i" % _i
         assert "already exists in file" in str(w[0].message), "Run %i" % _i
+
+
+def test_get_waveform_attributes(example_data_set):
+    with ASDFDataSet(example_data_set.filename) as ds:
+        assert ds.waveforms.AE_113A.get_waveform_attributes() == {
+            'AE.113A..BHE__2013-05-24T05:40:00__'
+            '2013-05-24T06:50:00__raw_recording': {
+                'event_ids': [
+                    'smi:service.iris.edu/fdsnws/event/1/query?'
+                    'eventid=4218658'],
+                'sampling_rate': 40.0,
+                'starttime': 1369374000000000000},
+            'AE.113A..BHN__2013-05-24T05:40:00__'
+            '2013-05-24T06:50:00__raw_recording': {
+                'event_ids': [
+                    'smi:service.iris.edu/fdsnws/event/1/query?'
+                    'eventid=4218658'],
+                'sampling_rate': 40.0,
+                'starttime': 1369374000000000000},
+            'AE.113A..BHZ__2013-05-24T05:40:00__'
+            '2013-05-24T06:50:00__raw_recording': {
+                'event_ids': [
+                    'smi:service.iris.edu/fdsnws/event/1/query?'
+                    'eventid=4218658'],
+                'sampling_rate': 40.0,
+                'starttime': 1369374000000000000}
+        }

--- a/pyasdf/utils.py
+++ b/pyasdf/utils.py
@@ -726,6 +726,39 @@ class WaveformAccessor(object):
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    def get_waveform_attributes(self):
+        """
+        Get a dictionary of the attributes of all waveform data sets.
+
+        This works purely on the meta data level and is thus fast. Event,
+        origin, arrival, and focmec ids will be returned as lists as they can
+        be set multiple times per data-set.
+        """
+        plural_keys = ["event_id", "origin_id",
+                       "magnitude_id", "focal_mechanism_id"]
+
+        attributes = {}
+        for _i in self.list():
+            if _i == "StationXML":
+                continue
+
+            attrs = {}
+            for k, v in self.__hdf5_group[_i].attrs.items():
+                # Make sure its an actual string.
+                try:
+                    v = v.decode()
+                except Exception:
+                    pass
+
+                if k in plural_keys:
+                    k += "s"
+                    v = v.split(",")
+                attrs[k] = v
+            if attrs:
+                attributes[_i] = attrs
+
+        return attributes
+
     @property
     def coordinates(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,11 @@ Changelog
 ---------
 
 ::
+    Version 0.4.x (TBD)
+    -------------------
+    * New get_waveform_attributes() method to quickly get all attributes
+      for the waveforms of a stations (see #38, #39).
+
     Version 0.3.0 (October 19, 2017)
     ----------------------------------
     * Support for ASDF 1.0.1 (the only difference to 1.0.0 is support for


### PR DESCRIPTION
New method `get_waveform_attributes()` that returns a dictionary with all HDF5 attributes for each waveform in a station. Makes it simpler to write things requiring fast access to the attributes of waveforms without parsing them or directly accessing the h5py objects.

Includes tests and an example in the documentation for how to use it.

Fixes #38.