### PR TITLE
Add microseconds to waveform name if necessary.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
 

--- a/pyasdf/asdf_data_set.py
+++ b/pyasdf/asdf_data_set.py
@@ -1294,10 +1294,19 @@ class ASDFDataSet(object):
             ds.attrs[key] = value
 
     def __get_waveform_ds_name(self, net, sta, loc, cha, start, end, tag):
+        fmt_string = "%Y-%m-%dT%H:%M:%S"
+        s = start.strftime(fmt_string)
+        e = start.strftime(fmt_string)
+
+        # Add microseconds if two waveforms start in the same second
+        if s == e:
+            fmt_string = "%Y-%m-%dT%H:%M:%S.%f"
+            s = start.strftime(fmt_string)
+            e = start.strftime(fmt_string)
+
         return "{net}.{sta}.{loc}.{cha}__{start}__{end}__{tag}".format(
             net=net, sta=sta, loc=loc, cha=cha,
-            start=start.strftime("%Y-%m-%dT%H:%M:%S"),
-            end=end.strftime("%Y-%m-%dT%H:%M:%S"),
+            start=s, end=e,
             tag=tag)
 
     def _add_trace_get_collective_information(

--- a/pyasdf/asdf_data_set.py
+++ b/pyasdf/asdf_data_set.py
@@ -1313,8 +1313,8 @@ class ASDFDataSet(object):
         # Add nanoseconds if two waveforms start in the same second. Only do
         # so for recent ASDF versions.
         if s == e and self._loose_asdf_format_version >= LooseVersion("1.0.2"):
-            s = "." + "%09i" % (start._ns % int(1e9))
-            e = "." + "%09i" % (end._ns % int(1e9))
+            s += "." + "%09i" % (start._ns % int(1e9))
+            e += "." + "%09i" % (end._ns % int(1e9))
 
         return "{net}.{sta}.{loc}.{cha}__{start}__{end}__{tag}".format(
             net=net, sta=sta, loc=loc, cha=cha,

--- a/pyasdf/header.py
+++ b/pyasdf/header.py
@@ -39,7 +39,7 @@ for key, value in list(COMPRESSIONS.items()):
 
 
 FORMAT_NAME = "ASDF"
-SUPPORTED_FORMAT_VERSIONS = ("1.0.0", "1.0.1")
+SUPPORTED_FORMAT_VERSIONS = ("1.0.0", "1.0.1", "1.0.2")
 
 
 # Regular expression for allowed filenames within the provenance group.
@@ -55,6 +55,11 @@ VALID_SEISMOGRAM_DTYPES = {
               np.dtype("<f4"), np.dtype(">f4"),
               np.dtype("<f8"), np.dtype(">f8")),
     "1.0.1": (np.dtype("<i2"), np.dtype(">i2"),
+              np.dtype("<i4"), np.dtype(">i4"),
+              np.dtype("<i8"), np.dtype(">i8"),
+              np.dtype("<f4"), np.dtype(">f4"),
+              np.dtype("<f8"), np.dtype(">f8")),
+    "1.0.2": (np.dtype("<i2"), np.dtype(">i2"),
               np.dtype("<i4"), np.dtype(">i4"),
               np.dtype("<i8"), np.dtype(">i8"),
               np.dtype("<f4"), np.dtype(">f4"),

--- a/pyasdf/tests/test_asdf_data_set.py
+++ b/pyasdf/tests/test_asdf_data_set.py
@@ -264,7 +264,7 @@ def test_assert_format_and_version_number_are_written(tmpdir):
     # Open again and assert name and version number.
     with h5py.File(asdf_filename, "r") as hdf5_file:
         assert hdf5_file.attrs["file_format_version"].decode() \
-           == "1.0.1"
+           == "1.0.2"
         assert hdf5_file.attrs["file_format"].decode() == FORMAT_NAME
 
 
@@ -506,16 +506,25 @@ def test_format_version_handling(tmpdir):
 
     # Create.
     with ASDFDataSet(filename) as ds:
-        assert ds.asdf_format_version_in_file == "1.0.1"
-        assert ds.asdf_format_version == "1.0.1"
+        assert ds.asdf_format_version_in_file == "1.0.2"
+        assert ds.asdf_format_version == "1.0.2"
     # Open again.
     with ASDFDataSet(filename) as ds:
-        assert ds.asdf_format_version_in_file == "1.0.1"
-        assert ds.asdf_format_version == "1.0.1"
+        assert ds.asdf_format_version_in_file == "1.0.2"
+        assert ds.asdf_format_version == "1.0.2"
 
     os.remove(filename)
 
     # Directly specify it.
+    with ASDFDataSet(filename, format_version="1.0.2") as ds:
+        assert ds.asdf_format_version_in_file == "1.0.2"
+        assert ds.asdf_format_version == "1.0.2"
+    with ASDFDataSet(filename) as ds:
+        assert ds.asdf_format_version_in_file == "1.0.2"
+        assert ds.asdf_format_version == "1.0.2"
+
+    os.remove(filename)
+
     with ASDFDataSet(filename, format_version="1.0.1") as ds:
         assert ds.asdf_format_version_in_file == "1.0.1"
         assert ds.asdf_format_version == "1.0.1"
@@ -558,17 +567,17 @@ def test_format_version_handling(tmpdir):
         ds._ASDFDataSet__file.attrs["file_format_version"] = \
             ds._zeropad_ascii_string("x.x.x")
         assert ds.asdf_format_version_in_file == "x.x.x"
-        assert ds.asdf_format_version == "1.0.1"
+        assert ds.asdf_format_version == "1.0.2"
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         with ASDFDataSet(filename) as ds:
             assert ds.asdf_format_version_in_file == "x.x.x"
-            assert ds.asdf_format_version == "1.0.1"
+            assert ds.asdf_format_version == "1.0.2"
     assert w[0].message.args[0] == (
         "The file claims an ASDF version of x.x.x. This version of pyasdf "
-        "only supports versions: 1.0.0, 1.0.1. All following write operations "
-        "will use version 1.0.1 - other tools might not be able to read "
-        "the files again - proceed with caution.")
+        "only supports versions: 1.0.0, 1.0.1, 1.0.2. All following write "
+        "operations will use version 1.0.2 - other tools might not be able to "
+        "read the files again - proceed with caution.")
     # Again but force version.
     os.remove(filename)
     # Both can also differ.
@@ -583,9 +592,9 @@ def test_format_version_handling(tmpdir):
             assert ds.asdf_format_version == "1.0.0"
     assert w[0].message.args[0] == (
         "The file claims an ASDF version of x.x.x. This version of pyasdf "
-        "only supports versions: 1.0.0, 1.0.1. All following write operations "
-        "will use version 1.0.0 - other tools might not be able to read "
-        "the files again - proceed with caution.")
+        "only supports versions: 1.0.0, 1.0.1, 1.0.2. All following write "
+        "operations will use version 1.0.0 - other tools might not be able to "
+        "read the files again - proceed with caution.")
 
     # Unsupported version number.
     os.remove(filename)
@@ -593,7 +602,7 @@ def test_format_version_handling(tmpdir):
         ASDFDataSet(filename, format_version="x.x.x")
     assert err.value.args[0] == (
         "ASDF version 'x.x.x' is not supported. Supported versions: 1.0.0, "
-        "1.0.1")
+        "1.0.1, 1.0.2")
     # No file should be created.
     assert not os.path.exists(filename)
 
@@ -605,8 +614,8 @@ def test_format_version_handling(tmpdir):
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         with ASDFDataSet(filename) as ds:
-            assert ds.asdf_format_version_in_file == "1.0.1"
-            assert ds.asdf_format_version == "1.0.1"
+            assert ds.asdf_format_version_in_file == "1.0.2"
+            assert ds.asdf_format_version == "1.0.2"
     assert w[0].message.args[0] == (
         "No file format version given in file '%s'. The program will "
         "continue but the result is undefined." % os.path.abspath(filename))

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,8 @@ Changelog
 ::
     Version 0.4.x (TBD)
     -------------------
+    * Support for ASDF version 1.0.2. Allows writing traces that are less than
+      one second short (see #44, #45).
     * New get_waveform_attributes() method to quickly get all attributes
       for the waveforms of a stations (see #38, #39).
 


### PR DESCRIPTION
[WIP, just found the tests folder]
This pull request fixes #44 by checking for a start and end time within the same second, then adding microseconds if necessary. PR's to ASDF_definition and asdf_validate address this potential change to the ASDF file.

I don't think it's necessary to add the additional check
```
if s == e:
    raise ValueError("Some sensible error message")
```
The goal was to avoid rejecting separate waveforms that matched timestamps in seconds but not microseconds. If the start and end still match in microseconds that probably just means an npts=0 trace was added. Maybe someone has a reason to do this?