### PR TITLE
Add HDF5 RegionReferences for efficiently windowing waveform segments from continuous data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.egg-info
 doc/_build/
 .cache
+*.pyc

--- a/pyasdf/asdf_data_set.py
+++ b/pyasdf/asdf_data_set.py
@@ -1325,40 +1325,28 @@ class ASDFDataSet(object):
         etc...
         """
 
-        if isinstance(net, str) or isinstance(net, unicode):
-            net = (net,)
-        elif isinstance(net, tuple) or isinstance(net, list) or net is None:
-            pass
-        else:
-            raise(TypeError(net))
+        def _coerce(obj):
+            if isinstance(obj, str):
+                obj = (obj,)
+            elif isinstance(obj, tuple)\
+                    or isinstance(obj, list)\
+                    or obj is None:
+                pass
+            else:
+                try:
+                    if isinstance(obj, unicode):
+                        obj = (obj,)
+                    else:
+                        raise(TypeError(obj))
+                except NameError:
+                    pass
+            return(obj)
 
-        if isinstance(sta, str) or isinstance(sta, unicode):
-            sta = (sta,)
-        elif isinstance(sta, tuple) or isinstance(sta, list) or sta is None:
-            pass
-        else:
-            raise(TypeError(sta))
-
-        if isinstance(loc, str) or isinstance(loc, unicode):
-            loc = (loc,)
-        elif isinstance(loc, tuple) or isinstance(loc, list) or loc is None:
-            pass
-        else:
-            raise(TypeError(loc))
-
-        if isinstance(chan, str) or isinstance(chan, unicode):
-            chan = (chan,)
-        elif isinstance(chan, tuple) or isinstance(chan, list) or chan is None:
-            pass
-        else:
-            raise(TypeError(chan))
-
-        if isinstance(tag, str) or isinstance(tag, unicode):
-            tag = (tag,)
-        elif isinstance(tag, tuple) or isinstance(tag, list) or tag is None:
-            pass
-        else:
-            raise(TypeError(tag))
+        net = _coerce(net)
+        sta = _coerce(sta)
+        loc = _coerce(loc)
+        chan = _coerce(chan)
+        tag = _coerce(tag)
 
         _ref_dtype = h5py.special_dtype(ref=h5py.RegionReference)
 
@@ -1386,10 +1374,10 @@ class ASDFDataSet(object):
                    and _predicate_tag(_key))
 
         _wf_grp = self._waveform_group
-        for _station_name in itertools.ifilter(_predicate_netsta,
-                                               self._waveform_group.keys()):
-            for _key in itertools.ifilter(_predicate_locchantag,
-                                          _wf_grp[_station_name].keys()):
+        for _station_name in filter(_predicate_netsta,
+                                    self._waveform_group.keys()):
+            for _key in filter(_predicate_locchantag,
+                               _wf_grp[_station_name].keys()):
 
                 _net, _sta, _loc, _remainder = _key.split(".")
                 _chan = _remainder.split("__")[0]
@@ -1494,38 +1482,29 @@ class ASDFDataSet(object):
 
         etc...
         """
-        if not isinstance(ref, str) and not isinstance(ref, unicode):
-            raise(TypeError("reference must be type ::str::"))
         if ref not in self._reference_group:
             raise(IOError("reference does not exist: %s" % ref))
 
-        if isinstance(net, str) or isinstance(net, unicode):
-            net = (net,)
-        elif isinstance(net, tuple) or isinstance(net, list) or net is None:
-            pass
-        else:
-            raise(TypeError(net))
+        def _coerce(obj):
+            if isinstance(obj, str):
+                obj = (obj,)
+            elif isinstance(obj, tuple)\
+                    or isinstance(obj, list)\
+                    or obj is None:
+                pass
+            else:
+                try:
+                    if isinstance(obj, unicode):
+                        obj = (obj,)
+                    else:
+                        raise(TypeError(obj))
+                except NameError:
+                    pass
 
-        if isinstance(sta, str) or isinstance(sta, unicode):
-            sta = (sta,)
-        elif isinstance(sta, tuple) or isinstance(sta, list) or sta is None:
-            pass
-        else:
-            raise(TypeError(sta))
-
-        if isinstance(loc, str) or isinstance(loc, unicode):
-            loc = (loc,)
-        elif isinstance(loc, tuple) or isinstance(loc, list) or loc is None:
-            pass
-        else:
-            raise(TypeError(loc))
-
-        if isinstance(chan, str) or isinstance(chan, unicode):
-            chan = (chan,)
-        elif isinstance(chan, tuple) or isinstance(chan, list) or chan is None:
-            pass
-        else:
-            raise(TypeError(chan))
+        net = _coerce(net)
+        sta = _coerce(sta)
+        loc = _coerce(loc)
+        chan = _coerce(chan)
 
         def _predicate_net(_key):
             return(net is None or _key in net)
@@ -1541,20 +1520,16 @@ class ASDFDataSet(object):
 
         _st = obspy.Stream()
         _ref_grp = self._reference_group[ref]
-        for _net in itertools.ifilter(_predicate_net,
-                                      _ref_grp.keys()):
+        for _net in filter(_predicate_net, _ref_grp.keys()):
             _net_grp = _ref_grp[_net]
 
-            for _sta in itertools.ifilter(_predicate_sta,
-                                          _net_grp.keys()):
+            for _sta in filter(_predicate_sta, _net_grp.keys()):
                 _sta_grp = _net_grp[_sta]
 
-                for _loc in itertools.ifilter(_predicate_loc,
-                                              _sta_grp.keys()):
+                for _loc in filter(_predicate_loc, _sta_grp.keys()):
                     _loc_grp = _sta_grp[_loc]
 
-                    for _chan in itertools.ifilter(_predicate_chan,
-                                                   _loc_grp.keys()):
+                    for _chan in filter(_predicate_chan, _loc_grp.keys()):
                         _ds = _loc_grp[_chan]
                         _ref = _ds[0]
                         _tr = obspy.Trace(data=self.__file[_ref][_ref])

--- a/pyasdf/asdf_data_set.py
+++ b/pyasdf/asdf_data_set.py
@@ -246,8 +246,8 @@ class ASDFDataSet(object):
             self.__file.create_group("Provenance")
         if "AuxiliaryData" not in self.__file and mode != "r":
             self.__file.create_group("AuxiliaryData")
-        if "References" not in self.__file and mode != "r":
-            self.__file.create_group("References")
+        if "References" not in self.__file["AuxiliaryData"] and mode != "r":
+            self.__file.create_group("AuxiliaryData/References")
 
         # Easy access to the waveforms.
         self.waveforms = StationAccessor(self)
@@ -366,7 +366,7 @@ class ASDFDataSet(object):
 
     @property
     def _reference_group(self):
-        return self.__file["References"]
+        return self.__file["AuxiliaryData/References"]
 
     @property
     def asdf_format_version_in_file(self):
@@ -1234,7 +1234,7 @@ class ASDFDataSet(object):
     def create_reference(self, ref, starttime, endtime, net=None, sta=None,
                          loc=None, chan=None, tag=None, overwrite=False):
         """
-        Creates a region reference for fast lookup of data segments.
+        Creates a reference for fast lookup of data segments.
 
         :param ref: The reference label to apply.
         :type ref: str
@@ -1348,8 +1348,6 @@ class ASDFDataSet(object):
         chan = _coerce(chan)
         tag = _coerce(tag)
 
-        #_ref_dtype = h5py.special_dtype(ref=h5py.RegionReference)
-
         def _predicate_net(_key):
             return(net is None or _key.split(".")[0] in net)
 
@@ -1390,7 +1388,6 @@ class ASDFDataSet(object):
 
                 _offset = int((starttime-_ts)*_samprate)
                 _nsamp = int(round((endtime-starttime)*_samprate, 0))
-                #_ref = _ds.regionref[_offset:_offset+_nsamp+1]
 
                 if ref not in self._reference_group:
                     _ref_grp = self._reference_group.create_group(ref)

--- a/pyasdf/asdf_data_set.py
+++ b/pyasdf/asdf_data_set.py
@@ -1376,9 +1376,9 @@ class ASDFDataSet(object):
         _wf_grp = self._waveform_group
         for _station_name in filter(_predicate_netsta,
                                     self._waveform_group.keys()):
+            print(_station_name)
             for _key in filter(_predicate_locchantag,
                                _wf_grp[_station_name].keys()):
-
                 _net, _sta, _loc, _remainder = _key.split(".")
                 _chan = _remainder.split("__")[0]
 
@@ -1500,6 +1500,7 @@ class ASDFDataSet(object):
                         raise(TypeError(obj))
                 except NameError:
                     pass
+            return(obj)
 
         net = _coerce(net)
         sta = _coerce(sta)

--- a/pyasdf/tests/test_asdf_data_set.py
+++ b/pyasdf/tests/test_asdf_data_set.py
@@ -87,6 +87,36 @@ def test_waveform_tags_attribute(tmpdir):
     assert data_set.waveform_tags == expected
 
 
+def test_reference_creation(tmpdir):
+    asdf_filename = os.path.join(tmpdir.strpath, "test.h5")
+    data_path = os.path.join(data_dir, "small_sample_data_set")
+
+    data_set = ASDFDataSet(asdf_filename)
+
+    for filename in glob.glob(os.path.join(data_path, "*.mseed")):
+        data_set.add_waveforms(filename, tag="raw")
+
+    data_set.create_reference("ref1",
+                              obspy.UTCDateTime("2013-05-24T05:50:00"),
+                              obspy.UTCDateTime("2013-05-24T05:55:00"),
+                              net="AE")
+    st = data_set.get_data_for_reference("ref1")
+
+    assert len(st) == 3
+    for tr in st:
+        assert tr.stats.network == "AE"
+
+    data_set.create_reference("ref2",
+                              obspy.UTCDateTime("2013-05-24T05:50:00"),
+                              obspy.UTCDateTime("2013-05-24T05:55:00"),
+                              chan="BHZ")
+    st = data_set.get_data_for_reference("ref2")
+
+    assert len(st) == 2
+    for tr in st:
+        assert tr.stats.channel == "BHZ"
+
+
 def test_data_set_creation(tmpdir):
     """
     Test data set creation with a small test dataset.

--- a/pyasdf/tests/test_asdf_data_set.py
+++ b/pyasdf/tests/test_asdf_data_set.py
@@ -101,7 +101,6 @@ def test_reference_creation(tmpdir):
                               obspy.UTCDateTime("2013-05-24T05:55:00"),
                               net="AE")
     st = data_set.get_data_for_reference("ref1")
-
     assert len(st) == 3
     for tr in st:
         assert tr.stats.network == "AE"
@@ -111,10 +110,31 @@ def test_reference_creation(tmpdir):
                               obspy.UTCDateTime("2013-05-24T05:55:00"),
                               chan="BHZ")
     st = data_set.get_data_for_reference("ref2")
-
     assert len(st) == 2
     for tr in st:
         assert tr.stats.channel == "BHZ"
+
+    data_set.create_reference("ref3",
+                              obspy.UTCDateTime("2013-05-24T05:50:00"),
+                              obspy.UTCDateTime("2013-05-24T05:55:00"),
+                              chan=("BHN", "BHE"))
+    st = data_set.get_data_for_reference("ref3")
+    assert len(st) == 4
+    for tr in st:
+        assert tr.stats.channel in ("BHN", "BHE")
+
+    data_set.create_reference("ref4",
+                              obspy.UTCDateTime("2013-05-24T05:50:00"),
+                              obspy.UTCDateTime("2013-05-24T05:55:00"),
+                              net="TA",
+                              sta=("POKR",),
+                              chan="BHZ")
+    st = data_set.get_data_for_reference("ref4")
+    assert len(st) == 1
+    for tr in st:
+        assert tr.stats.channel == "BHZ"\
+                and tr.stats.station == "POKR"\
+                and tr.stats.network == "TA"
 
 
 def test_data_set_creation(tmpdir):


### PR DESCRIPTION
I have added a new data group--**/References**--for fast access to referenced regions of continuous waveforms. The intended use is for efficiently creating segmented waveforms, by windowing continuous data, without duplicating waveforms.
 
An example use case is if one has a continuous waveform archive and wishes to process event-segmented waveforms, based on some event catalog. Re-running the same processing for a different event catalog would typically require re-extracting the waveforms, which will likely duplicate many data and can be time consuming. Using HDF5 region references allows the user to simply create a new set of pointers to the relevant data, saving time and storage.