### PR TITLE
Use bash executable instead of sh

### DIFF
--- a/.travis-update-gh-pages.sh
+++ b/.travis-update-gh-pages.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # based on: http://sleepycoders.blogspot.se/2013/03/sharing-travis-ci-generated-files.html
 
 # Only do it if not acting on a pull request.


### PR DESCRIPTION
`#!/bin/bash` should always be used over `#!/bin/sh`, some reasons provided [here](https://askubuntu.com/questions/141928/what-is-the-difference-between-bin-sh-and-bin-bash).